### PR TITLE
Ytv3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem 'unicorn'
 gem 'backports'
 gem 'memcachier'
 gem 'dalli'
-gem 'youtube_it'
+gem 'yt', '~> 0.14.5'
 
 # For old-style action_caching
 gem "actionpack-action_caching"
@@ -94,6 +94,7 @@ group :development, :test do
 
   # This loads environment variables from rails_root/.env if that file exists.
   gem 'dotenv-rails'
+
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,8 @@ GEM
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.2.19)
     builder (3.2.2)
+    byebug (4.0.5)
+      columnize (= 0.9.0)
     capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -95,6 +97,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.9.1.1)
+    columnize (0.9.0)
     concord (0.1.5)
       adamantium (~> 0.2.0)
       equalizer (~> 0.0.9)
@@ -308,6 +311,11 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-byebug (3.1.0)
+      byebug (~> 4.0)
+      pry (~> 0.10)
+    pry-rails (0.3.4)
+      pry (>= 0.9.10)
     ptools (1.3.2)
     pusher-client (0.6.0)
       json
@@ -493,6 +501,8 @@ GEM
       oauth (~> 0.4.4)
       oauth2 (~> 1.0.0)
       simple_oauth (>= 0.1.5)
+    yt (0.14.5)
+      activesupport
     zonebie (0.5.1)
 
 PLATFORMS
@@ -535,6 +545,8 @@ DEPENDENCIES
   omniauth
   omniauth-github
   pg
+  pry-byebug
+  pry-rails
   quiet_assets
   rack-livereload
   rails (= 4.2.1)
@@ -559,4 +571,5 @@ DEPENDENCIES
   uglifier
   unicorn
   youtube_it
+  yt (~> 0.14.5)
   zonebie

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,8 +70,6 @@ GEM
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.2.19)
     builder (3.2.2)
-    byebug (4.0.5)
-      columnize (= 0.9.0)
     capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -97,7 +95,6 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.9.1.1)
-    columnize (0.9.0)
     concord (0.1.5)
       adamantium (~> 0.2.0)
       equalizer (~> 0.0.9)
@@ -155,7 +152,6 @@ GEM
     ethon (0.7.3)
       ffi (>= 1.3.0)
     eventmachine (1.0.7)
-    excon (0.45.1)
     execjs (2.5.2)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
@@ -282,7 +278,6 @@ GEM
       nenv (~> 0.1)
       shellany (~> 0.0)
     ntlm-http (0.1.1)
-    oauth (0.4.7)
     oauth2 (1.0.0)
       faraday (>= 0.8, < 0.10)
       jwt (~> 1.0)
@@ -311,11 +306,6 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    pry-byebug (3.1.0)
-      byebug (~> 4.0)
-      pry (~> 0.10)
-    pry-rails (0.3.4)
-      pry (>= 0.9.10)
     ptools (1.3.2)
     pusher-client (0.6.0)
       json
@@ -417,7 +407,6 @@ GEM
     simple_form (3.1.0)
       actionpack (~> 4.0)
       activemodel (~> 4.0)
-    simple_oauth (0.3.1)
     simplecov (0.9.2)
       docile (~> 1.1.0)
       multi_json (~> 1.0)
@@ -492,15 +481,6 @@ GEM
     websocket (1.2.1)
     xpath (2.0.0)
       nokogiri (~> 1.3)
-    youtube_it (2.4.2)
-      builder
-      excon
-      faraday (>= 0.8, < 0.10)
-      json (~> 1.8)
-      nokogiri (~> 1.6.0)
-      oauth (~> 0.4.4)
-      oauth2 (~> 1.0.0)
-      simple_oauth (>= 0.1.5)
     yt (0.14.5)
       activesupport
     zonebie (0.5.1)
@@ -545,8 +525,6 @@ DEPENDENCIES
   omniauth
   omniauth-github
   pg
-  pry-byebug
-  pry-rails
   quiet_assets
   rack-livereload
   rails (= 4.2.1)
@@ -570,6 +548,5 @@ DEPENDENCIES
   tzinfo
   uglifier
   unicorn
-  youtube_it
   yt (~> 0.14.5)
   zonebie

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -38,9 +38,9 @@ class ContentController < ApplicationController
     def load_videos
       @videos            = Video.all
       @most_recent_video = @videos.first
-      @other_videos      = @videos[1..5]
+      @other_videos      = @videos.map(&:video)[1..5]
       @player            = %Q{<iframe width="560" height="315"
-        src="#{@most_recent_video.embed_url}" frameborder="0"
+        src="#{Video.embed_url(@most_recent_video.video_id)}" frameborder="0"
         allowfullscreen></iframe>}
       @playlist_url      = Video.playlist_url
     end

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -38,9 +38,10 @@ class ContentController < ApplicationController
     def load_videos
       @videos            = Video.all
       @most_recent_video = @videos.first
+      @mrv_id            = @most_recent_video.video_id
       @other_videos      = @videos.map(&:video)[1..5]
       @player            = %Q{<iframe width="560" height="315"
-        src="#{Video.embed_url(@most_recent_video.video_id)}" frameborder="0"
+        src="#{Video.embed_url(@mrv_id)}" frameborder="0"
         allowfullscreen></iframe>}
       @playlist_url      = Video.playlist_url
     end

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -3,19 +3,26 @@ require 'youtube_it'
 class Video
 
   def self.all
-    playlist.videos
+    playlist.playlist_items
   end
 
   def self.playlist_url
     "http://www.youtube.com/playlist?list=#{playlist_id}"
   end
 
+  def self.player_url(video_id)
+    "https://www.youtube.com/watch?v=#{video_id}&feature=youtube_gdata_player"
+  end
+
+  def self.embed_url(video_id)
+    "http://www.youtube.com/v/#{video_id}&feature=youtube_gdata_player"
+  end
+
   private
 
   def self.playlist
     @_playlist ||= begin
-      client = YouTubeIt::Client.new(:dev_key => ENV['YOUTUBE_KEY'])
-      client.playlist playlist_id
+      Yt::Playlist.new url: playlist_url
     end
   end
 

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -1,5 +1,3 @@
-require 'youtube_it'
-
 class Video
 
   def self.all

--- a/app/views/content/_videos.html.haml
+++ b/app/views/content/_videos.html.haml
@@ -1,7 +1,7 @@
 #videos
   - if @most_recent_video.present?
     %h1
-      %a{:href => Video.player_url(@most_recent_video.video_id)}= @most_recent_video.title
+      %a{:href => Video.player_url(@mrv_id)}= @most_recent_video.title
     = raw @player
     - if @other_videos.any?
       %h3 Other videos

--- a/app/views/content/_videos.html.haml
+++ b/app/views/content/_videos.html.haml
@@ -1,14 +1,14 @@
 #videos
   - if @most_recent_video.present?
     %h1
-      %a{:href => @most_recent_video.player_url}= @most_recent_video.title
+      %a{:href => Video.player_url(@most_recent_video.video_id)}= @most_recent_video.title
     = raw @player
     - if @other_videos.any?
       %h3 Other videos
       %ul.other-list
         - @other_videos.each do |video|
           %li
-            %a{:href => video.player_url}= video.title
+            %a{:href => Video.player_url(video.id)}= video.title
     %h4
       See more newer stuff on
       = link_to "Atlanta Ruby Users' Group Talk Series on YouTube", @playlist_url

--- a/config/initializers/yt.rb
+++ b/config/initializers/yt.rb
@@ -1,3 +1,4 @@
 Yt.configure do |config|
   config.api_key = ENV['YOUTUBE_KEY']
+  config.log_level = :debug
 end

--- a/config/initializers/yt.rb
+++ b/config/initializers/yt.rb
@@ -1,0 +1,4 @@
+Yt.configure do |config|
+  config.api_key = ENV['YOUTUBE_KEY']
+  config.log_level = :debug
+end

--- a/config/initializers/yt.rb
+++ b/config/initializers/yt.rb
@@ -1,4 +1,3 @@
 Yt.configure do |config|
   config.api_key = ENV['YOUTUBE_KEY']
-  config.log_level = :debug
 end


### PR DESCRIPTION
tried to give this one a shot, I figured that atlrug does not need oauth2 even though the yt gem states that they only support oauth2, regular calls via the public api still work for v3 and through yt. If you think atlrug needs oauth2 for v3, then my implementation won't work.

[youtube api v3 public access](https://developers.google.com/youtube/2.0/deprecation_faq#anonymity)

http://www.sitepoint.com/youtube-api-version-3-rails/ - "- Read-only access, not requiring user authentication, is also supported. You need to provide an API key that identifies your project"

your going to have to go to https://console.developers.google.com, register the production app, whitelist the production ip, and add the new API key as YOUTUBE_KEY in production (via `config/initializers/yt.rb`).

So everything works when I run it locally and the tests pass, I put in on heroku, but because of the changing ip addresses, the youtube api wont allow access. so I didn't get it tested in a production environment.

Another thing that might be worth mentioning, Youtube_it returned data that included the video url link, but yt does not, so I added class methods on Video to generate the urls, hopefully that works for your side. Let me know what your thinking